### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,9 +37,9 @@ The following diagram shows the contribution workflow:
 
 * Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
 * Complete the pull request providing the information listed in the template.
-  * **We will close your pull request if you do not provide the information described in the template.**
+  - **We will close your pull request if you do not provide the information described in the template.**
 * After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
-  * **We will close your pull request if you do not respond to feedback in two weeks.**
+  - **We will close your pull request if you do not respond to feedback in two weeks.**
 
 >**Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.
 
@@ -67,9 +67,9 @@ The following guidelines may answer most of your questions and help you get star
 * Do not make changes to content in the Announcements and Support Tools folders.
 * Do not remove/change the HTML formatting mentioned as required in [Support KB formatting](../docs/guides/kb-formatting-guide.md).
 * Do not remove/change the HTML formatting in Troubleshooters articles.
-  * Examples:
-    * [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
-    * [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
+  - Examples:
+    + [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
+    + [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
 
 ## File structure
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,16 +29,16 @@ The following diagram shows the contribution workflow:
 
 ### Create a branch
 
-* Create a new branch from your fork using a name that best describes the work or references a GitHub issue number.
-* Edit or create markdown (`.md`) files in your branch.
-* Push your branch to your fork.
+1. Create a new branch from your fork using a name that best describes the work or references a GitHub issue number.
+2. Edit or create markdown (`.md`) files in your branch.
+3. Push your branch to your fork.
 
 ### Create a pull request
 
-* Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
-* Complete the pull request providing the information listed in the template.
+1. Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
+2. Complete the pull request providing the information listed in the template.
     * **We will close your pull request if you do not provide the information described in the template.**
-* After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
+3. After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
     * **We will close your pull request if you do not respond to feedback in two weeks.**
 
 >**Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,11 +37,11 @@ The following diagram shows the contribution workflow:
 
 * Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
 * Complete the pull request providing the information listed in the template.
-  * **We will close your pull request if you do not provide the information described in the template.**
+	* **We will close your pull request if you do not provide the information described in the template.**
 * After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
-  * **We will close your pull request if you do not respond to feedback in two weeks.**
+	* **We will close your pull request if you do not respond to feedback in two weeks.**
 
-> **Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.
+>**Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.
 
 ## General contribution guidelines
 
@@ -66,15 +66,15 @@ The following guidelines may answer most of your questions and help you get star
 
 * Do not make changes to content in the Announcements and Support Tools folders.
 * Do not remove/change the HTML formatting mentioned as required in [Support KB formatting](../docs/guides/kb-formatting-guide.md).
-* Do not remove/change the HTML formatting in Troubleshooters articles. 
-  * Examples:
-    * [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
-    * [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
+* Do not remove/change the HTML formatting in Troubleshooters articles.
+	* Examples:
+		* [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
+		* [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
 
 ## File structure
 
-* All `.md` files should go to sections folders, nested in category folders under the "src" folder.
-* All images and any other attachments should go to "assets" folders inside the section folders.
+All `.md` files should go to sections folders, nested in category folders under the "src" folder.
+All images and any other attachments should go to "assets" folders inside the section folders.
 
 ### Article files naming convention
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,12 +15,10 @@ As you contribute PRs, you gain [Contribution Points](../docs/contribution-point
 
 ## Get started
 
-
 ![Get started workflow](../docs/img/contributor_start.png)
 
 1. Make sure you have a [GitHub account](https://github.com/signup/free).
-
-    **Note for partners:** Add [2FA](https://devdocs.magento.com/contributor-guide/contributing.html#two-factor) protection when contributing to Magento repositories.
+   - **Note for partners:** Add [2FA](https://devdocs.magento.com/contributor-guide/contributing.html#two-factor) protection when contributing to Magento repositories.
 
 1. [Fork](https://help.github.com/articles/fork-a-repo/) the [Support KB repository](https://github.com/magento/knowledge-base). Remember to [sync your fork](https://help.github.com/articles/syncing-a-fork/) and update branches as needed.
 1. Review the [Support KB guidelines below](#contribution-guidelines).
@@ -58,7 +56,7 @@ The following diagram shows the contribution workflow:
 * Review existing [pull requests](https://github.com/magento/knowledge-base/pulls) and [issues](https://github.com/magento/knowledge-base/issues) to avoid duplicating work.
 * For large contributions, or changes that include multiple files, [open an issue](#report-an-issue) and discuss it with us first. This helps prevent duplicate or unnecessary work.
 * Do not make global find-and-replace changes without first [creating an issue](https://github.com/magento/knowledge-base/issues/new/choose) and discussing it with us. Global changes can have unintended consequences.
-* Combine multiple small changes (such as minor editorial and technical changes) into a single pull request. This helps us efficiently and effectively facilitate your contribution.
+* Combine multiple small changes (_such as minor editorial and technical changes_) into a single pull request. This helps us efficiently and effectively facilitate your contribution.
 * Review your work for basic typos, formatting errors, or ambiguous sentences before opening a pull request.
 
 ## Specific contribution guidelines
@@ -81,7 +79,7 @@ The following guidelines may answer most of your questions and help you get star
     * [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
 
 
-## File structure {#file_structure}
+## File structure
 
 All .md files should go to sections folders, nested in category folders under the "src" folder.
 All images and any other attachments should go to "assets" folders inside the section folders.
@@ -103,7 +101,7 @@ If you add images to your articles, please follow this convention to name your i
 
 ### Metadata
 
-The Markdown (.md) file's metadata is a set of YAML key-value pairs. The metadata section is located at the top of each file. Non-ASCII characters are not allowed in metadata.
+The Markdown (`.md`) file's metadata is a set of YAML key-value pairs. The metadata section is located at the top of each file. Non-ASCII characters are not allowed in metadata.
 
 ```yaml
 ---
@@ -133,7 +131,7 @@ To rename the article, update the title in the article's metadata. It will refle
 
 #### Add/Edit/Delete article labels
 
-To add, edit, or delete article labels (tags), update the labels portion of the metadata.
+To add, edit, or delete article labels (_tags_), update the labels portion of the metadata.
 
 #### Edit article body
 
@@ -149,7 +147,7 @@ To delete an article, delete the article file.
 
 ## Report an issue
 
-If you find a typo or errors in Magento Support Knowledge Base article, you can either correct it and deliver changes with a pull request (as described above), or you can report it by creating an issue in the Support KB repository.
+If you find a typo or errors in Magento Support Knowledge Base article, you can either correct it and deliver changes with a pull request (_as described above_), or you can report it by creating an issue in the Support KB repository.
 
 You must complete the issue template. We will close your issue if you fail to provide the information listed template. Enter as much information as you can, including content corrections, steps to reproduce, command or code updates, or questions for clarifications.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,9 +37,9 @@ The following diagram shows the contribution workflow:
 
 * Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
 * Complete the pull request providing the information listed in the template.
-  - **We will close your pull request if you do not provide the information described in the template.**
+   * **We will close your pull request if you do not provide the information described in the template.**
 * After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
-  - **We will close your pull request if you do not respond to feedback in two weeks.**
+   * **We will close your pull request if you do not respond to feedback in two weeks.**
 
 >**Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.
 
@@ -67,9 +67,9 @@ The following guidelines may answer most of your questions and help you get star
 * Do not make changes to content in the Announcements and Support Tools folders.
 * Do not remove/change the HTML formatting mentioned as required in [Support KB formatting](../docs/guides/kb-formatting-guide.md).
 * Do not remove/change the HTML formatting in Troubleshooters articles.
-  - Examples:
-    + [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
-    + [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
+   * Examples:
+      * [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
+      * [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
 
 ## File structure
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,11 +37,11 @@ The following diagram shows the contribution workflow:
 
 * Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
 * Complete the pull request providing the information listed in the template.
-  - **We will close your pull request if you do not provide the information described in the template.**
+  * **We will close your pull request if you do not provide the information described in the template.**
 * After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
-  - **We will close your pull request if you do not respond to feedback in two weeks.**
+  * **We will close your pull request if you do not respond to feedback in two weeks.**
 
->**Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.
+> **Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.
 
 ## General contribution guidelines
 
@@ -67,9 +67,9 @@ The following guidelines may answer most of your questions and help you get star
 * Do not make changes to content in the Announcements and Support Tools folders.
 * Do not remove/change the HTML formatting mentioned as required in [Support KB formatting](../docs/guides/kb-formatting-guide.md).
 * Do not remove/change the HTML formatting in Troubleshooters articles. 
-  - Examples:
-    + [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
-    + [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
+  * Examples:
+    * [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
+    * [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
 
 ## File structure
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,15 +30,15 @@ The following diagram shows the contribution workflow:
 ### Create a branch
 
 1. Create a new branch from your fork using a name that best describes the work or references a GitHub issue number.
-2. Edit or create markdown (`.md`) files in your branch.
-3. Push your branch to your fork.
+1. Edit or create markdown (`.md`) files in your branch.
+1. Push your branch to your fork.
 
 ### Create a pull request
 
 1. Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
-2. Complete the pull request providing the information listed in the template.
+1. Complete the pull request providing the information listed in the template.
     * **We will close your pull request if you do not provide the information described in the template.**
-3. After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
+1. After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
     * **We will close your pull request if you do not respond to feedback in two weeks.**
 
 >**Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -15,9 +15,9 @@ As you contribute PRs, you gain [Contribution Points](../docs/contribution-point
 
 ![Get started workflow](../docs/img/contributor_start.png)
 
-- Make sure you have a [GitHub account](https://github.com/signup/free).
-- [Fork](https://help.github.com/articles/fork-a-repo/) the [Support KB repository](https://github.com/magento/knowledge-base). Remember to [sync your fork](https://help.github.com/articles/syncing-a-fork/) and update branches as needed.
-- Review the [Support KB guidelines below](#contribution-guidelines).
+* Make sure you have a [GitHub account](https://github.com/signup/free).
+* [Fork](https://help.github.com/articles/fork-a-repo/) the [Support KB repository](https://github.com/magento/knowledge-base). Remember to [sync your fork](https://help.github.com/articles/syncing-a-fork/) and update branches as needed.
+* Review the [Support KB guidelines below](#contribution-guidelines).
 
 >**Note for partners:** Add [2FA](https://devdocs.magento.com/contributor-guide/contributing.html#two-factor) protection when contributing to Magento repositories.
 
@@ -29,27 +29,27 @@ The following diagram shows the contribution workflow:
 
 ### Create a branch
 
-- Create a new branch from your fork using a name that best describes the work or references a GitHub issue number.
-- Edit or create markdown (`.md`) files in your branch.
-- Push your branch to your fork.
+* Create a new branch from your fork using a name that best describes the work or references a GitHub issue number.
+* Edit or create markdown (`.md`) files in your branch.
+* Push your branch to your fork.
 
 ### Create a pull request
 
-- Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
-- Complete the pull request providing the information listed in the template.
-   - **We will close your pull request if you do not provide the information described in the template.**
-- After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
-   - **We will close your pull request if you do not respond to feedback in two weeks.**
+* Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
+* Complete the pull request providing the information listed in the template.
+  - **We will close your pull request if you do not provide the information described in the template.**
+* After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
+  - **We will close your pull request if you do not respond to feedback in two weeks.**
 
 >**Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.
 
 ## General contribution guidelines
 
-- Review existing [pull requests](https://github.com/magento/knowledge-base/pulls) and [issues](https://github.com/magento/knowledge-base/issues) to avoid duplicating work.
-- For large contributions, or changes that include multiple files, [open an issue](#report-an-issue) and discuss it with us first. This helps prevent duplicate or unnecessary work.
-- Do not make global find-and-replace changes without first [creating an issue](https://github.com/magento/knowledge-base/issues/new/choose) and discussing it with us. Global changes can have unintended consequences.
-- Combine multiple small changes (_such as minor editorial and technical changes_) into a single pull request. This helps us efficiently and effectively facilitate your contribution.
-- Review your work for basic typos, formatting errors, or ambiguous sentences before opening a pull request.
+* Review existing [pull requests](https://github.com/magento/knowledge-base/pulls) and [issues](https://github.com/magento/knowledge-base/issues) to avoid duplicating work.
+* For large contributions, or changes that include multiple files, [open an issue](#report-an-issue) and discuss it with us first. This helps prevent duplicate or unnecessary work.
+* Do not make global find-and-replace changes without first [creating an issue](https://github.com/magento/knowledge-base/issues/new/choose) and discussing it with us. Global changes can have unintended consequences.
+* Combine multiple small changes (_such as minor editorial and technical changes_) into a single pull request. This helps us efficiently and effectively facilitate your contribution.
+* Review your work for basic typos, formatting errors, or ambiguous sentences before opening a pull request.
 
 ## Specific contribution guidelines
 
@@ -57,24 +57,24 @@ The following guidelines may answer most of your questions and help you get star
 
 ### Dos:
 
-- Write content using Markdown. See [Support KB formatting](../docs/guides/kb-formatting-guide.md) for details.
-- Please follow the style recommendations described in [Support KB Styleguide](../docs/guides/support-kb-styleguide.md).
-- Use [article templates](../docs/article-templates/) when adding new articles.
-- Follow the recommended file structure and file naming convention described further.
+* Write content using Markdown. See [Support KB formatting](../docs/guides/kb-formatting-guide.md) for details.
+* Please follow the style recommendations described in [Support KB Styleguide](../docs/guides/support-kb-styleguide.md).
+* Use [article templates](../docs/article-templates/) when adding new articles.
+* Follow the recommended file structure and file naming convention described further.
 
 ### Don'ts
 
-- Do not make changes to content in the Announcements and Support Tools folders.
-- Do not remove/change the HTML formatting mentioned as required in [Support KB formatting](../docs/guides/kb-formatting-guide.md).
-- Do not remove/change the HTML formatting in Troubleshooters articles. 
-	- Examples:
-		- [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
-		- [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
+* Do not make changes to content in the Announcements and Support Tools folders.
+* Do not remove/change the HTML formatting mentioned as required in [Support KB formatting](../docs/guides/kb-formatting-guide.md).
+* Do not remove/change the HTML formatting in Troubleshooters articles. 
+  - Examples:
+    + [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
+    + [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
 
 ## File structure
 
-All `.md` files should go to sections folders, nested in category folders under the "src" folder.
-All images and any other attachments should go to "assets" folders inside the section folders.
+* All `.md` files should go to sections folders, nested in category folders under the "src" folder.
+* All images and any other attachments should go to "assets" folders inside the section folders.
 
 ### Article files naming convention
 
@@ -84,17 +84,17 @@ All file and folder names must be lower cased with "-" in between all words. Fil
 
 If you add images to your articles, please follow this convention to name your image files:
 
-- Specify version of the product which is represented on the screenshot. If it is not Magento Commerce, add name of the product to the file name.
-- Relay what is being captured by the image, for example a screenshot of Magento Commerce Price Rule configuration would be cart-price-rule-new-231.png, cart-price-rule-saved-231.png etc. Check for existing images to follow the naming patterns.
-- Lower case.
-- Words should be separated by hyphen "-", not underscore "_".
-- Use existing naming patterns. Check the existing file names under /assets folders as an example.
+* Specify version of the product which is represented on the screenshot. If it is not Magento Commerce, add name of the product to the file name.
+* Relay what is being captured by the image, for example a screenshot of Magento Commerce Price Rule configuration would be cart-price-rule-new-231.png, cart-price-rule-saved-231.png etc. Check for existing images to follow the naming patterns.
+* Lower case.
+* Words should be separated by hyphen "-", not underscore "_".
+* Use existing naming patterns. Check the existing file names under /assets folders as an example.
 
 ### Metadata
 
 The Markdown (`.md`) file's metadata is a set of YAML key-value pairs. The metadata section is located at the top of each file. Non-ASCII characters are not allowed in metadata.
 
-```
+```yaml
 ---
 title:
 labels:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,9 +37,9 @@ The following diagram shows the contribution workflow:
 
 * Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
 * Complete the pull request providing the information listed in the template.
-	* **We will close your pull request if you do not provide the information described in the template.**
+  * **We will close your pull request if you do not provide the information described in the template.**
 * After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
-	* **We will close your pull request if you do not respond to feedback in two weeks.**
+  * **We will close your pull request if you do not respond to feedback in two weeks.**
 
 >**Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.
 
@@ -67,9 +67,9 @@ The following guidelines may answer most of your questions and help you get star
 * Do not make changes to content in the Announcements and Support Tools folders.
 * Do not remove/change the HTML formatting mentioned as required in [Support KB formatting](../docs/guides/kb-formatting-guide.md).
 * Do not remove/change the HTML formatting in Troubleshooters articles.
-	* Examples:
-		* [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
-		* [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
+  * Examples:
+    * [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
+    * [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
 
 ## File structure
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,4 @@
-
-## Contribute to Magento Support Knowledge base
+## Contribute to Magento Support Knowledge Base
 
 Share your troubleshooting tips and best practices with the community by contributing to [Magento Support Knowledge Base](https://support.magento.com/hc/en-us) (Support KB)!
 You can contribute by creating an issue or pull request (PR) on our [Support KB](https://github.com/magento/knowledge-base) GitHub repository.
@@ -12,17 +11,15 @@ Support KB staff members review issues and pull requests on a regular basis. We 
 Support KB works with Magento Community Engineering teams and projects.
 As you contribute PRs, you gain [Contribution Points](../docs/contribution-points.md).
 
-
 ## Get started
 
 ![Get started workflow](../docs/img/contributor_start.png)
 
-1. Make sure you have a [GitHub account](https://github.com/signup/free).
-   - **Note for partners:** Add [2FA](https://devdocs.magento.com/contributor-guide/contributing.html#two-factor) protection when contributing to Magento repositories.
+- Make sure you have a [GitHub account](https://github.com/signup/free).
+- [Fork](https://help.github.com/articles/fork-a-repo/) the [Support KB repository](https://github.com/magento/knowledge-base). Remember to [sync your fork](https://help.github.com/articles/syncing-a-fork/) and update branches as needed.
+- Review the [Support KB guidelines below](#contribution-guidelines).
 
-1. [Fork](https://help.github.com/articles/fork-a-repo/) the [Support KB repository](https://github.com/magento/knowledge-base). Remember to [sync your fork](https://help.github.com/articles/syncing-a-fork/) and update branches as needed.
-1. Review the [Support KB guidelines below](#contribution-guidelines).
-
+>**Note for partners:** Add [2FA](https://devdocs.magento.com/contributor-guide/contributing.html#two-factor) protection when contributing to Magento repositories.
 
 ## Contribute
 
@@ -30,34 +27,29 @@ The following diagram shows the contribution workflow:
 
 ![Contributing workflow](../docs/img/Contributor-PR.png)
 
-
 ### Create a branch
 
-1. Create a new branch from your fork using a name that best describes the work or references a GitHub issue number.
-1. Edit or create markdown (`.md`) files in your branch.
-1. Push your branch to your fork.
+- Create a new branch from your fork using a name that best describes the work or references a GitHub issue number.
+- Edit or create markdown (`.md`) files in your branch.
+- Push your branch to your fork.
 
 ### Create a pull request
 
-1. Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
+- Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
+- Complete the pull request providing the information listed in the template.
+   - **We will close your pull request if you do not provide the information described in the template.**
+- After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
+   - **We will close your pull request if you do not respond to feedback in two weeks.**
 
-1. Complete the pull request providing the information listed in the template.
-
-   **We will close your pull request if you do not provide the information described in the template.**
-
-1. After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
-
-   **We will close your pull request if you do not respond to feedback in two weeks.**
-
-**Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.
+>**Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.
 
 ## General contribution guidelines
 
-* Review existing [pull requests](https://github.com/magento/knowledge-base/pulls) and [issues](https://github.com/magento/knowledge-base/issues) to avoid duplicating work.
-* For large contributions, or changes that include multiple files, [open an issue](#report-an-issue) and discuss it with us first. This helps prevent duplicate or unnecessary work.
-* Do not make global find-and-replace changes without first [creating an issue](https://github.com/magento/knowledge-base/issues/new/choose) and discussing it with us. Global changes can have unintended consequences.
-* Combine multiple small changes (_such as minor editorial and technical changes_) into a single pull request. This helps us efficiently and effectively facilitate your contribution.
-* Review your work for basic typos, formatting errors, or ambiguous sentences before opening a pull request.
+- Review existing [pull requests](https://github.com/magento/knowledge-base/pulls) and [issues](https://github.com/magento/knowledge-base/issues) to avoid duplicating work.
+- For large contributions, or changes that include multiple files, [open an issue](#report-an-issue) and discuss it with us first. This helps prevent duplicate or unnecessary work.
+- Do not make global find-and-replace changes without first [creating an issue](https://github.com/magento/knowledge-base/issues/new/choose) and discussing it with us. Global changes can have unintended consequences.
+- Combine multiple small changes (_such as minor editorial and technical changes_) into a single pull request. This helps us efficiently and effectively facilitate your contribution.
+- Review your work for basic typos, formatting errors, or ambiguous sentences before opening a pull request.
 
 ## Specific contribution guidelines
 
@@ -65,25 +57,24 @@ The following guidelines may answer most of your questions and help you get star
 
 ### Dos:
 
-* Write content using Markdown. See [Support KB formatting](../docs/guides/kb-formatting-guide.md) for details.
-* Please follow the style recommendations described in [Support KB Styleguide](../docs/guides/support-kb-styleguide.md).
-* Use [article templates](../docs/article-templates/) when adding new articles.
-* Follow the recommended file structure and file naming convention described further.
+- Write content using Markdown. See [Support KB formatting](../docs/guides/kb-formatting-guide.md) for details.
+- Please follow the style recommendations described in [Support KB Styleguide](../docs/guides/support-kb-styleguide.md).
+- Use [article templates](../docs/article-templates/) when adding new articles.
+- Follow the recommended file structure and file naming convention described further.
 
 ### Don'ts
 
-* Do not make changes to content in the Announcements and Support Tools folders.
-* Do not remove/change the HTML formatting mentioned as required in [Support KB formatting](../docs/guides/kb-formatting-guide.md).
-* Do not remove/change the HTML formatting in Troubleshooters articles. Examples:
-   * [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
-   * [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
-
+- Do not make changes to content in the Announcements and Support Tools folders.
+- Do not remove/change the HTML formatting mentioned as required in [Support KB formatting](../docs/guides/kb-formatting-guide.md).
+- Do not remove/change the HTML formatting in Troubleshooters articles. 
+	- Examples:
+		- [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
+		- [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
 
 ## File structure
 
 All `.md` files should go to sections folders, nested in category folders under the "src" folder.
 All images and any other attachments should go to "assets" folders inside the section folders.
-
 
 ### Article files naming convention
 
@@ -93,17 +84,17 @@ All file and folder names must be lower cased with "-" in between all words. Fil
 
 If you add images to your articles, please follow this convention to name your image files:
 
-* Specify version of the product which is represented on the screenshot. If it is not Magento Commerce, add name of the product to the file name.
-* Relay what is being captured by the image, for example a screenshot of Magento Commerce Price Rule configuration would be cart-price-rule-new-231.png, cart-price-rule-saved-231.png etc. Check for existing images to follow the naming patterns.
-* Lower case.
-* Words should be separated by hyphen "-", not underscore "_".
-* Use existing naming patterns. Check the existing file names under /assets folders as an example.
+- Specify version of the product which is represented on the screenshot. If it is not Magento Commerce, add name of the product to the file name.
+- Relay what is being captured by the image, for example a screenshot of Magento Commerce Price Rule configuration would be cart-price-rule-new-231.png, cart-price-rule-saved-231.png etc. Check for existing images to follow the naming patterns.
+- Lower case.
+- Words should be separated by hyphen "-", not underscore "_".
+- Use existing naming patterns. Check the existing file names under /assets folders as an example.
 
 ### Metadata
 
 The Markdown (`.md`) file's metadata is a set of YAML key-value pairs. The metadata section is located at the top of each file. Non-ASCII characters are not allowed in metadata.
 
-```yaml
+```
 ---
 title:
 labels:
@@ -116,7 +107,6 @@ labels:
 | ------------- | ---------- |
 | `title` | Defines the article title. If using any [YAML special characters](https://support.asg.com/mob/mvw/10_0/mv_ag/using_quotes_with_yaml_special_characters.htm) in title, please enclose it in quotes ("")|
 | `labels` | Contains labels that will be added to the article in Magento Help Center. Add labels to describe products, issues, products versions, section and category. If in doubt, don't add labels. |
-
 
 ### Add article
 
@@ -151,6 +141,6 @@ If you find a typo or errors in Magento Support Knowledge Base article, you can 
 
 You must complete the issue template. We will close your issue if you fail to provide the information listed template. Enter as much information as you can, including content corrections, steps to reproduce, command or code updates, or questions for clarifications.
 
-**Note:** Check the existing [issues](https://github.com/magento/knowledge-base/issues) on GitHub to see if someone has already reported the issue.
+> **Note:** Check the existing [issues](https://github.com/magento/knowledge-base/issues) on GitHub to see if someone has already reported the issue.
 
 Thank you for contributing your brilliance to Magento Support Knowledge Base!!

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -67,9 +67,9 @@ The following guidelines may answer most of your questions and help you get star
 * Do not make changes to content in the Announcements and Support Tools folders.
 * Do not remove/change the HTML formatting mentioned as required in [Support KB formatting](../docs/guides/kb-formatting-guide.md).
 * Do not remove/change the HTML formatting in Troubleshooters articles.
-   * Examples:
-      * [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
-      * [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
+    * Examples:
+        * [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
+        * [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
 
 ## File structure
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -43,11 +43,11 @@ The following diagram shows the contribution workflow:
 
 1. Complete the pull request providing the information listed in the template.
 
-    **We will close your pull request if you do not provide the information described in the template.**
+   **We will close your pull request if you do not provide the information described in the template.**
 
 1. After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
 
-    **We will close your pull request if you do not respond to feedback in two weeks.**
+   **We will close your pull request if you do not respond to feedback in two weeks.**
 
 **Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.
 
@@ -75,17 +75,17 @@ The following guidelines may answer most of your questions and help you get star
 * Do not make changes to content in the Announcements and Support Tools folders.
 * Do not remove/change the HTML formatting mentioned as required in [Support KB formatting](../docs/guides/kb-formatting-guide.md).
 * Do not remove/change the HTML formatting in Troubleshooters articles. Examples:
-    * [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
-    * [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
+   * [Redis troubleshooter](https://support.magento.com/hc/en-us/articles/360046673932)
+   * [Magento Fastly troubleshooter](https://support.magento.com/hc/en-us/articles/360040759292-Magento-Fastly-troubleshooter)
 
 
 ## File structure
 
-All .md files should go to sections folders, nested in category folders under the "src" folder.
+All `.md` files should go to sections folders, nested in category folders under the "src" folder.
 All images and any other attachments should go to "assets" folders inside the section folders.
 
 
-### Artilce files naming convention
+### Article files naming convention
 
 All file and folder names must be lower cased with "-" in between all words. File names should be descriptive and might coincide with future article title (but they don't define the title).
 
@@ -112,10 +112,10 @@ labels:
 
 > Key-value pair reference:
 
-| Property  | Description |
+| Property | Description |
 | ------------- | ---------- |
-| `title`       | Defines the article title. If using any [YAML special characters](https://support.asg.com/mob/mvw/10_0/mv_ag/using_quotes_with_yaml_special_characters.htm) in title, please enclose it in quotes ("")|
-| `labels` | Contains labels that will be added to the article in Magento Help Center. Add labels to describe products, issues, products versions, section and category.  If in doubt, don't add labels. |
+| `title` | Defines the article title. If using any [YAML special characters](https://support.asg.com/mob/mvw/10_0/mv_ag/using_quotes_with_yaml_special_characters.htm) in title, please enclose it in quotes ("")|
+| `labels` | Contains labels that will be added to the article in Magento Help Center. Add labels to describe products, issues, products versions, section and category. If in doubt, don't add labels. |
 
 
 ### Add article
@@ -152,6 +152,5 @@ If you find a typo or errors in Magento Support Knowledge Base article, you can 
 You must complete the issue template. We will close your issue if you fail to provide the information listed template. Enter as much information as you can, including content corrections, steps to reproduce, command or code updates, or questions for clarifications.
 
 **Note:** Check the existing [issues](https://github.com/magento/knowledge-base/issues) on GitHub to see if someone has already reported the issue.
-
 
 Thank you for contributing your brilliance to Magento Support Knowledge Base!!

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,9 +37,9 @@ The following diagram shows the contribution workflow:
 
 * Create a pull request to the [magento/knowledge-base](https://github.com/magento/knowledge-base) repository. Use `main` as the base branch when creating a PR.
 * Complete the pull request providing the information listed in the template.
-   * **We will close your pull request if you do not provide the information described in the template.**
+    * **We will close your pull request if you do not provide the information described in the template.**
 * After creating a pull request, a Support KB staff member will review it and may ask you to make revisions.
-   * **We will close your pull request if you do not respond to feedback in two weeks.**
+    * **We will close your pull request if you do not respond to feedback in two weeks.**
 
 >**Note:** If you have not signed the [Adobe Contributor License Agreement](https://opensource.adobe.com/cla.html), the pull request provides a link. You must sign the CLA before we can accept your contribution.
 


### PR DESCRIPTION
- Removed **{#file_structure}** from File Structure heading as it was showing a link to that heading as [https://github.com/magento/knowledge-base/blob/main/.github/CONTRIBUTING.md#file-structure-file_structure](https://github.com/magento/knowledge-base/blob/main/.github/CONTRIBUTING.md#file-structure-file_structure) instead of [https://github.com/magento/knowledge-base/blob/main/.github/CONTRIBUTING.md#file-structure](https://github.com/magento/knowledge-base/blob/main/.github/CONTRIBUTING.md#file-structure)

- And applied other small style fixes

## Purpose of this pull request
 
This pull request (PR) ...
 
## Affected Support KB pages
 
<!-- REQUIRED, unless the number of files is too big. -->
 
List the affected pages on support.magento.com (URLs).
 
<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`
 
-->
