### PR TITLE
Replace Magento with Adobe Commerce

### DIFF
--- a/src/best-practices/general/best-practices-for-render-blocking-resources-in-magento.md
+++ b/src/best-practices/general/best-practices-for-render-blocking-resources-in-magento.md
@@ -19,6 +19,6 @@ If assistance is required or if there are questions or concerns, [submit a suppo
 ## Related reading
 
 * [Adobe Commerce User Guide > Optimizing Resource Files](https://docs.magento.com/user-guide/system/file-optimization.html)
-* KB [Optimize CSS and JS files Adobe Commerce Cloud and Adobe Commerce](https://support.magento.com/hc/en-us/articles/360044482152-CSS-and-Javascript-file-optimization-on-Magento-Commerce-Cloud-and-Magento-Commerce) 
+* KB [Optimize CSS and JS files Adobe Commerce](https://support.magento.com/hc/en-us/articles/360044482152-CSS-and-Javascript-file-optimization-on-Magento-Commerce-Cloud-and-Magento-Commerce) 
 * DevDocs [Adobe Commerce > Frontend Developer Guide > Cascading style sheets (CSS) > CSS merging, minification and performance](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css-overview.html#css-merging-minification-and-performance) 
 

--- a/src/best-practices/general/best-practices-for-render-blocking-resources-in-magento.md
+++ b/src/best-practices/general/best-practices-for-render-blocking-resources-in-magento.md
@@ -1,24 +1,24 @@
 ---
-title: Best practices for render-blocking resources in Magento
+title: Best practices for render-blocking resources in Adobe Commerce
 labels: 2.3,2.3.x,2.4,2.4.x,CSS,Javascript,Magento Commerce,Magento Commerce Cloud,best practices
 ---
 
-This article provides guidance on preventing resources blocking page rendering in Magento, which can lead to a significant increase in page rendering time and cause performance degradation.
+This article provides guidance on preventing resources blocking page rendering in Adobe Commerce, which can lead to a significant increase in page rendering time and cause performance degradation.
 
 ## Affected products and versions
 
-* Magento Commerce, all [supported versions](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf)  
-* Magento Commerce Cloud, all [supported versions](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf) 
+* Adobe Commerce on-premise, all [supported versions](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf)  
+* Adobe Commerce Cloud, all [supported versions](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf) 
 
 ## Best practices
 
 Consider delivering critical JS/CSS features inline and deferring all non-critical JS/CSS styles. For guidance, refer to web.dev [Eliminate render-blocking resources](https://web.dev/render-blocking-resources/) .
 
-If assistance is required or if there are questions or concerns, [submit a Magento Support ticket](https://support.magento.com/hc/en-us/articles/360019088251-Submit-a-support-ticket) .
+If assistance is required or if there are questions or concerns, [submit a support ticket](https://support.magento.com/hc/en-us/articles/360019088251-Submit-a-support-ticket) .
 
 ## Related reading
 
-* [Magento User Guide > Optimizing Resource Files](https://docs.magento.com/user-guide/system/file-optimization.html)
-* KB [Optimize CSS and JS files Magento Commerce Cloud and Magento Commerce](https://support.magento.com/hc/en-us/articles/360044482152-CSS-and-Javascript-file-optimization-on-Magento-Commerce-Cloud-and-Magento-Commerce) 
-* DevDocs [Magento > Frontend Developer Guide > Cascading style sheets (CSS) > CSS merging, minification and performance](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css-overview.html#css-merging-minification-and-performance) 
+* [Adobe Commerce User Guide > Optimizing Resource Files](https://docs.magento.com/user-guide/system/file-optimization.html)
+* KB [Optimize CSS and JS files Adobe Commerce Cloud and Adobe Commerce](https://support.magento.com/hc/en-us/articles/360044482152-CSS-and-Javascript-file-optimization-on-Magento-Commerce-Cloud-and-Magento-Commerce) 
+* DevDocs [Adobe Commerce > Frontend Developer Guide > Cascading style sheets (CSS) > CSS merging, minification and performance](https://devdocs.magento.com/guides/v2.3/frontend-dev-guide/css-topics/css-overview.html#css-merging-minification-and-performance) 
 

--- a/src/best-practices/general/best-practices-for-render-blocking-resources-in-magento.md
+++ b/src/best-practices/general/best-practices-for-render-blocking-resources-in-magento.md
@@ -8,7 +8,7 @@ This article provides guidance on preventing resources blocking page rendering i
 ## Affected products and versions
 
 * Adobe Commerce on-premise, all [supported versions](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf)  
-* Adobe Commerce Cloud, all [supported versions](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf) 
+* Adobe Commerce on our cloud infrastructure, all [supported versions](https://magento.com/sites/default/files/magento-software-lifecycle-policy.pdf) 
 
 ## Best practices
 

--- a/src/troubleshooting/general/error-purging-cache-in-admin.md
+++ b/src/troubleshooting/general/error-purging-cache-in-admin.md
@@ -1,27 +1,27 @@
 ---
-title: Error purging cache in Magento Commerce Admin
-labels: Magento Commerce Cloud,admin,error,cache, 2.3.0, 2.4.2-p1, 2.3.7, 2.3.1, 2.3.2, 2.3.2-p2, 2.3.3, 2.3.3-p1, 2.3.4, 2.3.4-p2, 2.3.5-p1, 2.3.5-p2, 2.4.0, 2.3.6, 2.4.0-p1, 2.4.1, 2.3.6-p1, 2.4.2
+title: Error purging cache in Adobe Commerce Admin
+labels: Adobe Commerce, Magento Commerce Cloud,admin,error,cache, 2.3.0, 2.4.2-p1, 2.3.7, 2.3.1, 2.3.2, 2.3.2-p2, 2.3.3, 2.3.3-p1, 2.3.4, 2.3.4-p2, 2.3.5-p1, 2.3.5-p2, 2.4.0, 2.3.6, 2.4.0-p1, 2.4.1, 2.3.6-p1, 2.4.2
 ---
 
-This article explains how to identify the cause of an error message that occurs when purging the cache in Magento Commerce Admin. When you attempt to purge cache through the Admin you receive the following message:
+This article explains how to identify the cause of an error message that occurs when purging the cache in Adobe Commerce Admin. When you attempt to purge cache through the Admin you receive the following message:
 */app/project-id/pub/media/catalog/product/cache/directory/filename" file can't be deleted. Warning!unlink(/app/project id/pub/media/catalog/product/cache/directory/filename): No such file or directory*
 
 ## Affected products and versions
 
-Magento Commerce and Magento Commerce Cloud: 2.3.0-2.3.7, 2.4.0-2.4.2-p1
+Adobe Commerce and Adobe Commerce Cloud: 2.3.0-2.3.7, 2.4.0-2.4.2-p1
 
 ## Issue
 
-When you attempt to purge cache through the Magento Admin you receive an error message.
+When you attempt to purge cache through the Adobe Commerce Admin you receive an error message.
 
 <ins>Steps to reproduce:</ins>
 
-1. In Magento Admin, go to **System** > **Tools** > **Cache Management**. 
+1. In Adobe Commerce Admin, go to **System** > **Tools** > **Cache Management**. 
 1. Select any of the clear caching options.
 
 <ins>Expected result:</ins>
 
-You successfully flush Magento cache with no errors.
+You successfully flush Adobe Commerce cache with no errors.
 
 <ins>Actual result:</ins>
 

--- a/src/troubleshooting/general/error-purging-cache-in-admin.md
+++ b/src/troubleshooting/general/error-purging-cache-in-admin.md
@@ -8,7 +8,7 @@ This article explains how to identify the cause of an error message that occurs 
 
 ## Affected products and versions
 
-Adobe Commerce and Adobe Commerce Cloud: 2.3.0-2.3.7, 2.4.0-2.4.2-p1
+Adobe Commerce, all deployment types: 2.3.0-2.3.7, 2.4.0-2.4.2-p1
 
 ## Issue
 


### PR DESCRIPTION
## Purpose of this pull request
 
This pull request (PR) fixes issue #57 & #56
 
## Affected Support KB pages
 
https://support.magento.com/hc/en-us/articles/360049171211-Best-practices-for-render-blocking-resources-in-Magento-
https://support.magento.com/hc/en-us/articles/4402349423757-Error-purging-cache-in-Magento-Commerce-Admin

Query - The products are now known as Adobe Commerce & Adobe Commerce Cloud - using just commerce and then referring to "our cloud infrastructure" might be confusing and it a little long winded?



