### PR TITLE
Update reset-environment-on-cloud.md 

### DIFF
--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -114,8 +114,8 @@ git commit --allow-empty -m "<message>" && git push <origin> <branch>
 If executing the `setup:uninstall` command fails with an error and cannot be completed, we may clear the DB manually with these steps:
 
 1. [SSH to your environment](https://devdocs.magento.com/cloud/env/environments-ssh.html#ssh).
-1. Connect to the MySQL DB:    ```mysql -h database.internal```    
-   * For Pro environments see: [Set up MySQL service](https://devdocs.magento.com/cloud/project/services-mysql.html#connect-to-the-database)
+2. Connect to the MySQL DB:    ```mysql -h database.internal```    
+  * For Pro environments see: [Set up MySQL service](https://devdocs.magento.com/cloud/project/services-mysql.html#connect-to-the-database)
 3. Drop the \`main\` DB :    ```drop database main;```    
 4. Create an empty \`main\` DB:    ```create database main;```    
 5. Delete the following configuration files: `config.php` , `config.php` .bak, `env.php`, `env.php.bak`

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -65,7 +65,7 @@ Read: [Uninstall the Adobe Commerce software](https://devdocs.magento.com/guides
 To uninstall the Adobe Commerce software, follow these steps:
 
 1. [SSH to your environment](https://devdocs.magento.com/cloud/env/environments-ssh.html#ssh).
-1. Execute `setup:uninstall` :    ```bin/magento setup:uninstall```    
+1. Execute `setup:uninstall` : `bin/magento setup:uninstall`    
 1. Confirm uninstall.
 
 The following message displays to confirm a successful uninstallation:

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -114,10 +114,9 @@ git commit --allow-empty -m "<message>" && git push <origin> <branch>
 If executing the `setup:uninstall` command fails with an error and cannot be completed, we may clear the DB manually with these steps:
 
 1. [SSH to your environment](https://devdocs.magento.com/cloud/env/environments-ssh.html#ssh).
-2. Connect to the MySQL DB:    ```mysql -h database.internal```    
-  * For Pro environments see: [Set up MySQL service](https://devdocs.magento.com/cloud/project/services-mysql.html#connect-to-the-database)
-3. Drop the \`main\` DB :    ```drop database main;```    
-4. Create an empty \`main\` DB:    ```create database main;```    
-5. Delete the following configuration files: `config.php` , `config.php` .bak, `env.php`, `env.php.bak`
+1. Connect to the MySQL DB:    ```mysql -h database.internal``` ( For Pro environments see: [Set up MySQL service](https://devdocs.magento.com/cloud/project/services-mysql.html#connect-to-the-database) )
+1. Drop the \`main\` DB :    ```drop database main;```    
+1. Create an empty \`main\` DB:    ```create database main;```    
+1. Delete the following configuration files: `config.php` , `config.php` .bak, `env.php`, `env.php.bak`
 
 After resetting the DB, [make a git push to the environment to trigger redeploy](https://devdocs.magento.com/guides/v2.3/cloud/reference/cli-ref-topic.html#git-commands) and install Adobe Commerce to a newly created DB. Or [run the redeploy command](https://devdocs.magento.com/guides/v2.3/cloud/reference/cli-ref-topic.html#environment-commands).

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -81,7 +81,7 @@ This means we have reverted our Adobe Commerce installation (including DB) to it
 With git reset, we revert the code to the desired state in the past.
 
 1. Clone the environment to your local development environment. You may copy the command in your Project Web Interface:    ![copy_git_clone.png](assets/copy_git_clone.png)    
-1. Access the commits history. Use `--reverse` to display history in reverse order for more convenience:    ```git    git log --reverse    ```    
+1. Access the commits history. Use `--reverse` to display history in reverse order for more convenience: `git log--reverse`    
 1. Select the commit hash on which you've been good. To reset code to its authentic state (Vanilla), find the very first commit that created your branch (environment).    ![Selecting a commit hash in git console](assets/select_commit_hash.png)    
 1. Apply hard git reset: `git reset --h <commit_hash>`    
 1. Push changes to server: `git push --force <origin> <branch>`   

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -116,7 +116,7 @@ If executing the `setup:uninstall` command fails with an error and cannot be com
 1. [SSH to your environment](https://devdocs.magento.com/cloud/env/environments-ssh.html#ssh).
 1. Connect to the MySQL DB: `mysql -h database.internal` (For Pro environments see: [Set up MySQL service](https://devdocs.magento.com/cloud/project/services-mysql.html#connect-to-the-database) )
 1. Drop the \`main\` DB :    ```drop database main;```    
-1. Create an empty \`main\` DB:    ```create database main;```    
+1. Create an empty \`main\` DB: `create database main;`   
 1. Delete the following configuration files: `config.php` , `config.php` .bak, `env.php`, `env.php.bak`
 
 After resetting the DB, [make a git push to the environment to trigger redeploy](https://devdocs.magento.com/guides/v2.3/cloud/reference/cli-ref-topic.html#git-commands) and install Adobe Commerce to a newly created DB. Or [run the redeploy command](https://devdocs.magento.com/guides/v2.3/cloud/reference/cli-ref-topic.html#environment-commands).

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -115,8 +115,9 @@ If executing the `setup:uninstall` command fails with an error and cannot be com
 
 1. [SSH to your environment](https://devdocs.magento.com/cloud/env/environments-ssh.html#ssh).
 1. Connect to the MySQL DB:    ```mysql -h database.internal```    
-1. Drop the \`main\` DB :    ```sql    drop database main;```    
-1. Create an empty \`main\` DB:    ```sql    create database main;```    
-1. Delete the following configuration files: `config.php` , `config.php` .bak, `env.php`, `env.php.bak`
+   * For Pro environments see: [Set up MySQL service](https://devdocs.magento.com/cloud/project/services-mysql.html#connect-to-the-database)
+3. Drop the \`main\` DB :    ```drop database main;```    
+4. Create an empty \`main\` DB:    ```create database main;```    
+5. Delete the following configuration files: `config.php` , `config.php` .bak, `env.php`, `env.php.bak`
 
 After resetting the DB, [make a git push to the environment to trigger redeploy](https://devdocs.magento.com/guides/v2.3/cloud/reference/cli-ref-topic.html#git-commands) and install Adobe Commerce to a newly created DB. Or [run the redeploy command](https://devdocs.magento.com/guides/v2.3/cloud/reference/cli-ref-topic.html#environment-commands).

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -1,6 +1,6 @@
 ---
 title: Reset environment on Adobe Commerce on cloud infrastructure
-labels: 2.1.x,2.2.x,Magento Commerce Cloud,database,git,how to,restore,roll back,snapshot,uninstall,Adobe Commerce,cloud infrastructure
+labels: 2.1.x,2.2.x,,2.3.x,2.4.x,Magento Commerce Cloud,database,git,how to,restore,roll back,snapshot,uninstall,Adobe Commerce,cloud infrastructure
 ---
 
 This article shows different scenarios of rolling back an environment on Adobe Commerce on cloud infrastructure.
@@ -13,13 +13,13 @@ Choose the most appropriate for your case:
 
 ## Scenario 1: Restore a snapshot (easiest and recommended)
 
-Read: [Restore a snapshot on Adobe Commerce on cloud infrastructure](http://devdocs.magento.com/guides/v2.2/cloud/project/project-webint-snap.html#restore-snapshot) in our developer documentation.
+Read: [Restore a snapshot on Adobe Commerce on cloud infrastructure](https://devdocs.magento.com/cloud/project/project-webint-snap.html#restore-snapshot) in our developer documentation.
 
 >![info]
 >
 >Creating a snapshot must be our very first step after accessing the Adobe Commerce on cloud infrastructure account and before applying major changes. It is a best practice and highly recommended.
 
-Read: [Create a snapshot](http://devdocs.magento.com/guides/v2.2/cloud/project/project-webint-snap.html#create-snapshot) in our developer documentation.
+Read: [Create a snapshot](https://devdocs.magento.com/cloud/project/project-webint-snap.html#create-snapshot) in our developer documentation.
 
 ## Scenario 2: No snapshot, build stable (SSH connection available)
 
@@ -42,31 +42,30 @@ Read the detailed steps below.
 
 We need to disable Configuration Management so that it does not automatically apply the previous configuration settings during deployment.
 
-To disable Configuration Management, make sure that your `/app/etc/` directory does not contain the `config.php` (for Adobe Commerce 2.2.x) or `config.local.php` (for Adobe Commerce 2.1.x) files.
+To disable Configuration Management, make sure that your `/app/etc/` directory does not contain the `config.php`file.
 
 To remove the configuration file, follow these steps:
 
-1. [SSH to your environment](http://devdocs.magento.com/guides/v2.2/cloud/env/environments-ssh.html#ssh).
-1. Remove the configuration file:
-    * For Adobe Commerce 2.2:    ```php    rm app/etc/config.php    ```    
-    * For Adobe Commerce 2.1:    ```php    rm app/etc/config.local.php    ```    
+1. [SSH to your environment](https://devdocs.magento.com/cloud/env/environments-ssh.html#ssh).
+1. Remove the configuration file: ```rm app/etc/config.php```    
+   
 
 Read more about Configuration Management:
 
 * [Reduce deployment downtime on Adobe Commerce on cloud infrastructure](https://support.magento.com/hc/en-us/articles/115003169574) in our support knowledge base.
-* [Configuration management for store settings](http://devdocs.magento.com/guides/v2.2/cloud/live/sens-data-over.html) in our developer documentation.
+* [Configuration management for store settings](https://devdocs.magento.com/cloud/live/sens-data-over.html) in our developer documentation.
 
 ### Step 1: Uninstall the Adobe Commerce software with setup:uninstall command
 
 >
 Uninstalling the Adobe Commerce software drops and restores the database, removes the deployment configuration, and clears directories under \`var\`.
 
-Read: [Uninstall the Adobe Commerce software](http://devdocs.magento.com/guides/v2.2/install-gde/install/cli/install-cli-uninstall.html#instgde-install-uninstall) in our developer documentation.
+Read: [Uninstall the Adobe Commerce software](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-uninstall.html) in our developer documentation.
 
 To uninstall the Adobe Commerce software, follow these steps:
 
-1. [SSH to your environment](http://devdocs.magento.com/guides/v2.2/cloud/env/environments-ssh.html#ssh).
-1. Execute `setup:uninstall` :    ```php    php bin/magento setup:uninstall    ```    
+1. [SSH to your environment](https://devdocs.magento.com/cloud/env/environments-ssh.html#ssh).
+1. Execute `setup:uninstall` :    ```bin/magento setup:uninstall```    
 1. Confirm uninstall.
 
 The following message displays to confirm a successful uninstallation:
@@ -84,8 +83,8 @@ With git reset, we revert the code to the desired state in the past.
 1. Clone the environment to your local development environment. You may copy the command in your Project Web Interface:    ![copy_git_clone.png](assets/copy_git_clone.png)    
 1. Access the commits history. Use `--reverse` to display history in reverse order for more convenience:    ```git    git log --reverse    ```    
 1. Select the commit hash on which you've been good. To reset code to its authentic state (Vanilla), find the very first commit that created your branch (environment).    ![Selecting a commit hash in git console](assets/select_commit_hash.png)    
-1. Apply hard git reset:    ```git    git reset --h <commit_hash>    ```    
-1. Push changes to server:    ```git    git push --force <origin> <branch>    ```    
+1. Apply hard git reset:    ```git reset --h <commit_hash>```    
+1. Push changes to server:    ```git push --force <origin> <branch>```    
 
 After performing these steps, our git branch gets reset and the entire git changelog is clear. The last git push triggers the redeploy to apply all changes and re-install Adobe Commerce.
 
@@ -114,10 +113,10 @@ git commit --allow-empty -m "<message>" && git push <origin> <branch>
 
 If executing the `setup:uninstall` command fails with an error and cannot be completed, we may clear the DB manually with these steps:
 
-1. [SSH to your environment](http://devdocs.magento.com/guides/v2.2/cloud/env/environments-ssh.html#ssh).
-1. Connect to the MySQL DB:    ```sql    mysql -h database.internal    ```    
-1. Drop the \`main\` DB :    ```sql    drop database main;    ```    
-1. Create an empty \`main\` DB:    ```sql    create database main;    ```    
+1. [SSH to your environment](https://devdocs.magento.com/cloud/env/environments-ssh.html#ssh).
+1. Connect to the MySQL DB:    ```mysql -h database.internal```    
+1. Drop the \`main\` DB :    ```sql    drop database main;```    
+1. Create an empty \`main\` DB:    ```sql    create database main;```    
 1. Delete the following configuration files: `config.php` , `config.php` .bak, `env.php`, `env.php.bak`
 
 After resetting the DB, [make a git push to the environment to trigger redeploy](https://devdocs.magento.com/guides/v2.3/cloud/reference/cli-ref-topic.html#git-commands) and install Adobe Commerce to a newly created DB. Or [run the redeploy command](https://devdocs.magento.com/guides/v2.3/cloud/reference/cli-ref-topic.html#environment-commands).

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -114,7 +114,7 @@ git commit --allow-empty -m "<message>" && git push <origin> <branch>
 If executing the `setup:uninstall` command fails with an error and cannot be completed, we may clear the DB manually with these steps:
 
 1. [SSH to your environment](https://devdocs.magento.com/cloud/env/environments-ssh.html#ssh).
-1. Connect to the MySQL DB:    ```mysql -h database.internal``` ( For Pro environments see: [Set up MySQL service](https://devdocs.magento.com/cloud/project/services-mysql.html#connect-to-the-database) )
+1. Connect to the MySQL DB: `mysql -h database.internal` (For Pro environments see: [Set up MySQL service](https://devdocs.magento.com/cloud/project/services-mysql.html#connect-to-the-database) )
 1. Drop the \`main\` DB :    ```drop database main;```    
 1. Create an empty \`main\` DB:    ```create database main;```    
 1. Delete the following configuration files: `config.php` , `config.php` .bak, `env.php`, `env.php.bak`

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -82,7 +82,8 @@ With git reset, we revert the code to the desired state in the past.
 
 1. Clone the environment to your local development environment. You may copy the command in your Project Web Interface:    ![copy_git_clone.png](assets/copy_git_clone.png)    
 1. Access the commits history. Use `--reverse` to display history in reverse order for more convenience: `git log--reverse`    
-1. Select the commit hash on which you've been good. To reset code to its authentic state (Vanilla), find the very first commit that created your branch (environment).    ![Selecting a commit hash in git console](assets/select_commit_hash.png)    
+1. Select the commit hash on which you've been good. To reset code to its authentic state (Vanilla), find the very first commit that created your branch (environment). 
+![Selecting a commit hash in git console](assets/select_commit_hash.png)    
 1. Apply hard git reset: `git reset --h <commit_hash>`    
 1. Push changes to server: `git push --force <origin> <branch>`   
 

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -84,7 +84,7 @@ With git reset, we revert the code to the desired state in the past.
 1. Access the commits history. Use `--reverse` to display history in reverse order for more convenience:    ```git    git log --reverse    ```    
 1. Select the commit hash on which you've been good. To reset code to its authentic state (Vanilla), find the very first commit that created your branch (environment).    ![Selecting a commit hash in git console](assets/select_commit_hash.png)    
 1. Apply hard git reset:    ```git reset --h <commit_hash>```    
-1. Push changes to server:    ```git push --force <origin> <branch>```    
+1. Push changes to server: `git push --force <origin> <branch>`   
 
 After performing these steps, our git branch gets reset and the entire git changelog is clear. The last git push triggers the redeploy to apply all changes and re-install Adobe Commerce.
 

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -83,7 +83,7 @@ With git reset, we revert the code to the desired state in the past.
 1. Clone the environment to your local development environment. You may copy the command in your Project Web Interface:    ![copy_git_clone.png](assets/copy_git_clone.png)    
 1. Access the commits history. Use `--reverse` to display history in reverse order for more convenience:    ```git    git log --reverse    ```    
 1. Select the commit hash on which you've been good. To reset code to its authentic state (Vanilla), find the very first commit that created your branch (environment).    ![Selecting a commit hash in git console](assets/select_commit_hash.png)    
-1. Apply hard git reset:    ```git reset --h <commit_hash>```    
+1. Apply hard git reset: `git reset --h <commit_hash>`    
 1. Push changes to server: `git push --force <origin> <branch>`   
 
 After performing these steps, our git branch gets reset and the entire git changelog is clear. The last git push triggers the redeploy to apply all changes and re-install Adobe Commerce.

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -115,7 +115,7 @@ If executing the `setup:uninstall` command fails with an error and cannot be com
 
 1. [SSH to your environment](https://devdocs.magento.com/cloud/env/environments-ssh.html#ssh).
 1. Connect to the MySQL DB: `mysql -h database.internal` (For Pro environments see: [Set up MySQL service](https://devdocs.magento.com/cloud/project/services-mysql.html#connect-to-the-database) )
-1. Drop the \`main\` DB :    ```drop database main;```    
+1. Drop the \`main\` DB : `drop database main;`   
 1. Create an empty \`main\` DB: `create database main;`   
 1. Delete the following configuration files: `config.php` , `config.php` .bak, `env.php`, `env.php.bak`
 

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -47,7 +47,7 @@ To disable Configuration Management, make sure that your `/app/etc/` directory d
 To remove the configuration file, follow these steps:
 
 1. [SSH to your environment](https://devdocs.magento.com/cloud/env/environments-ssh.html#ssh).
-1. Remove the configuration file: ```rm app/etc/config.php```    
+1. Remove the configuration file: `rm app/etc/config.php`    
    
 
 Read more about Configuration Management:

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -117,6 +117,6 @@ If executing the `setup:uninstall` command fails with an error and cannot be com
 1. Connect to the MySQL DB: `mysql -h database.internal` (For Pro environments see: [Set up MySQL service](https://devdocs.magento.com/cloud/project/services-mysql.html#connect-to-the-database) )
 1. Drop the \`main\` DB : `drop database main;`   
 1. Create an empty \`main\` DB: `create database main;`   
-1. Delete the following configuration files: `config.php` , `config.php` .bak, `env.php`, `env.php.bak`
+1. Delete the following configuration files: `config.php` , `config.php` , `.bak`,  `env.php`, `env.php.bak`
 
 After resetting the DB, [make a git push to the environment to trigger redeploy](https://devdocs.magento.com/guides/v2.3/cloud/reference/cli-ref-topic.html#git-commands) and install Adobe Commerce to a newly created DB. Or [run the redeploy command](https://devdocs.magento.com/guides/v2.3/cloud/reference/cli-ref-topic.html#environment-commands).

--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -83,7 +83,7 @@ With git reset, we revert the code to the desired state in the past.
 1. Clone the environment to your local development environment. You may copy the command in your Project Web Interface:    ![copy_git_clone.png](assets/copy_git_clone.png)    
 1. Access the commits history. Use `--reverse` to display history in reverse order for more convenience: `git log--reverse`    
 1. Select the commit hash on which you've been good. To reset code to its authentic state (Vanilla), find the very first commit that created your branch (environment). 
-![Selecting a commit hash in git console](assets/select_commit_hash.png)    
+   ![Selecting a commit hash in git console](assets/select_commit_hash.png)    
 1. Apply hard git reset: `git reset --h <commit_hash>`    
 1. Push changes to server: `git push --force <origin> <branch>`   
 


### PR DESCRIPTION
## Purpose of this pull request
 
This pull request (PR) ...

1.  Updates links and instructions in reset-environment-on-cloud.md  to the current supported versions.
2.  Removed some github formatting that was causing extra words on the live site.
     * Example:  Execute `setup:uninstall : php php bin/magento setup:uninstall ` 
3.  Added reference to Pro environment connection string in the database connection instructions. 

 
List the affected pages on support.magento.com (URLs):

https://support.magento.com/hc/en-us/articles/360000852534-Reset-environment-on-Cloud
 

