### PR TITLE
Changed order of warning

### DIFF
--- a/src/support-tools/managed-alerts-for-adobe-commerce/managed-alerts-on-magento-commerce-redis-memory-warning-alert.md
+++ b/src/support-tools/managed-alerts-for-adobe-commerce/managed-alerts-on-magento-commerce-redis-memory-warning-alert.md
@@ -18,7 +18,7 @@ You will receive an alert in New Relic if you have signed up to [Managed alerts 
  **<u>Do!</u>**
 
 * It is recommended you abort any deployment scheduled until this alert is cleared.
-* Put your site into maintenance mode immediately if your site is or becomes completely unresponsive. For steps, refer to [Installation Guide > Enable or disable maintenance mode](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-subcommands-maint.html?itm_source=devdocs&itm_medium=search_page&itm_campaign=federated_search&itm_term=mainten) in our developer documentation.
+* If your site is or becomes completely unresponsive, immediately put your site into maintenance mode. For steps, refer to [Installation Guide > Enable or disable maintenance mode](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-subcommands-maint.html?itm_source=devdocs&itm_medium=search_page&itm_campaign=federated_search&itm_term=mainten) in our developer documentation.
 * Make sure to add your IP to the exempt IP address list to ensure that you are still able to access your site for troubleshooting. For steps, refer to [Maintain the list of exempt IP addresses](https://devdocs.magento.com/guides/v2.4/install-gde/install/cli/install-cli-subcommands-maint.html?itm_source=devdocs&itm_medium=search_page&itm_campaign=federated_search&itm_term=mainten#instgde-cli-maint-exempt) in our developer documentation.
 
  **<u>Don't!</u>**


### PR DESCRIPTION
## Purpose of this pull request
 
This pull request (PR) changes the order of the warning sentence to ensure the reader, reads all the sentence before seeing "put into maintenance mode"

It has been commented that a panicking reader might not read beyond this.
 
## Affected Support KB pages
https://support.magento.com/hc/en-us/articles/360049928852