### PR TITLE
Update mdva-41236-unable-to-create-new-or-edit-existing-scheduled-sta…

### DIFF
--- a/src/support-tools/patches-available-in-qpt-tool/mdva-41236-unable-to-create-new-or-edit-existing-scheduled-staging-update.md
+++ b/src/support-tools/patches-available-in-qpt-tool/mdva-41236-unable-to-create-new-or-edit-existing-scheduled-staging-update.md
@@ -3,7 +3,7 @@ title: "MDVA-41236: Unable to create new or edit existing scheduled updates for 
 labels: Support Tools,QPT patches,Quality Patches Tool,Magneto Commerce Cloud,QPT 1.1.5,Adobe Commerce,cloud infrastructure,on-premises,edit,create schedule,scheduled updates,peoduct,End Date,Start Date,2.3.0,2.3.1,2.3.2,2.3.3,2.3.2-p2,2.3.3-p1,2.3.4,2.3.4-p2,2.3.5,2.3.5-p1,2.3.5-p2,2.3.6,2.3.6-p1,2.3.7,2.3.7-p1,2.3.7-p2,2.4.0,2.4.0-p1,2.4.1,2.4.1-p1,2.4.2,2.4.2-p1,2.4.2-p2,2.4.3,2.4.3-p1
 ---
 
-The MDVA-41236 patch fixes the issue where users are unable to create new or edit existing scheduled updates for the product if the "End Date" has been previously removed. This patch is available when the [Quality Patches Tool (QPT)](https://devdocs.magento.com/guides/v2.4/comp-mgr/patching.html#mqp) 1.1.5 is installed. The patch ID is MDVA-41236. Please note that the issue is scheduled to be fixed in Adobe Commerce 2.4.4.
+The MDVA-41236 patch fixes the issue where users are unable to create new or edit existing scheduled updates for the product if the "End Date" has been previously removed. This patch is available when the [Quality Patches Tool (QPT)](https://devdocs.magento.com/guides/v2.4/comp-mgr/patching.html#mqp) 1.1.5 is installed. The patch ID is MDVA-41236. Please note that the issue is scheduled to be fixed in Adobe Commerce 2.4.5.
 
 ## Affected products and versions
 


### PR DESCRIPTION
## Purpose of this pull request

Correct fix version
 
## Affected Support KB pages
 
https://support.magento.com/hc/en-us/articles/4413127293965-MDVA-41236-Unable-to-create-new-or-edit-existing-scheduled-updates-for-product
