### PR TITLE
git log --reverse command was missing a space

### DIFF
--- a/src/how-to/general/reset-environment-on-cloud.md
+++ b/src/how-to/general/reset-environment-on-cloud.md
@@ -80,7 +80,7 @@ This means we have reverted our Adobe Commerce installation (including DB) to it
 With git reset, we revert the code to the desired state in the past.
 
 1. Clone the environment to your local development environment. You may copy the command in your Project Web Interface:    ![copy_git_clone.png](assets/copy_git_clone.png)    
-1. Access the commits history. Use `--reverse` to display history in reverse order for more convenience: `git log--reverse`    
+1. Access the commits history. Use `--reverse` to display history in reverse order for more convenience: `git log --reverse`    
 1. Select the commit hash on which you've been good. To reset code to its authentic state (Vanilla), find the very first commit that created your branch (environment).
     ![Selecting a commit hash in git console](assets/select_commit_hash.png)    
 1. Apply hard git reset: `git reset --h <commit_hash>`    


### PR DESCRIPTION
## Purpose of this pull request
 
Correct a syntax error in the git log --reverse command
 
## Affected Support KB pages

https://support.magento.com/hc/en-us/articles/360000852534-Reset-environment-on-Adobe-Commerce-on-cloud-infrastructure
 

