### PR TITLE
Remove controversial information

### DIFF
--- a/src/troubleshooting/database/mysql-high-load-bottleneck-in-magento-commerce-cloud.md
+++ b/src/troubleshooting/database/mysql-high-load-bottleneck-in-magento-commerce-cloud.md
@@ -45,10 +45,6 @@ If experiencing these two indications, enabling `SLAVE` connections for the MySQ
 
 Adobe Commerce can read multiple databases or Redis asynchronously. Updating the `.magento.env.yaml` file by setting to `true` the values `MYSQL_USE_SLAVE_CONNECTION` and `REDIS_USE_SLAVE_CONNECTION` to use a **read-only** connection to the database to receive read-only traffic on a non-master node. This improves performance through load balancing because only one node needs to handle read-write traffic. Set to `false` to remove any existing read-only connection array from the `env.php` file.
 
->![info]
->
->It is a best practice recommendation to always have MySQL slave connection enabled.
-
 ### Steps
 
 1. Edit your `.magento.env.yaml` file, and add the following content:    


### PR DESCRIPTION
It is not a best practice recommendation to always have MySQL slave connection enabled. 
Actually this even listed bellow in this article - "**On not-overloaded clusters** – **Slave Connections will slow down performance by 10-15%**, which is one of the reasons it is not default."

## Purpose of this pull request
 
This pull request (PR) ...
 
## Affected Support KB pages
 
<!-- REQUIRED, unless the number of files is too big. -->
 
List the affected pages on support.magento.com (URLs).
 
<!--
If you are fixing a GitHub issue, note it using GitHub keyword format (https://help.github.com/en/articles/closing-issues-using-keywords#closing-an-issue-in-a-different-repository) to close the issue when this pull request is merged. Example: `Fixes #1234`
 
-->
