### PR TITLE
Fix incorrect link

### DIFF
--- a/src/best-practices/general/troubleshooting-best-practices-for-magento-commerce-cloud.md
+++ b/src/best-practices/general/troubleshooting-best-practices-for-magento-commerce-cloud.md
@@ -30,7 +30,7 @@ Follow these best practices for effective troubleshooting of Adobe Commerce on c
 <td style="width: 179px;">Performance Issues</td>
 <td style="width: 523px;">
 <strong>If you're not using Adobe Commerce banner, disable it.</strong> When the banner is enabled but not used, resources are used to do lookups to the database when they are not required, and it will cause performance issues.</td>
-<td style="width: 327px;"><a href="https://learn.newrelic.com">Welcome to the New Relic University Learning Portal</a></td>
+<td style="width: 327px;"><a href="https://support.magento.com/hc/en-us/articles/360035285852-Disable-Adobe-Commerce-Banner-output-to-improve-site-performance">Disable Adobe Commerce Banner output to improve performance.</a> in our support knowledgebase.</td>
 </tr>
 <tr>
 <td style="width: 179px;">Search Issues</td>


### PR DESCRIPTION
## Purpose of this pull request
 
Corrects the link for the _Performance Issues - Disable Adobe Commerce banner_ item to point to the correct support article instead of the New Relic University Learning Portal.
 
## Affected Support KB pages
 
https://support.magento.com/hc/en-us/articles/360034340372-Troubleshooting-Best-Practices-for-Adobe-Commerce-on-cloud-infrastructure
