### PR TITLE
Update link to Upgrade documentation

### DIFF
--- a/src/best-practices/general/upgrade-plan-checklist-for-magento-commerce.md
+++ b/src/best-practices/general/upgrade-plan-checklist-for-magento-commerce.md
@@ -3,7 +3,7 @@ title: Upgrade plan checklist for Adobe Commerce
 labels: Certification program,Magento Commerce,Magento Commerce Cloud,Site-Wide Analysis Tool,Upgrade Compatibility Tool,best practices,deployment,extensions,security,third-party extensions,update,upgrade,Adobe Commerce
 ---
 
-Use this checklist during your annual and quarterly conversations with your ecommerce team. Many companies work from annual budgets and roadmaps. It is imperative, during these annual discussions, that you talk about your platform’s health, direction, and upgrade strategy for the year, along with how it fits into the overall goals and KPIs of the business. During quarterly conversations, make sure the annual plan you created is still aligned with your current situation or pivot if not. The goal of this Upgrade Plan Checklist is to help you plan and schedule Adobe Commerce upgrades, to ensure a successful upgrade process during the year. This checklist is meant to be used on annual planning and reviewed quarterly. This checklist is intended for:
+Use this checklist during your annual and quarterly conversations with your ecommerce team. Many companies work from annual budgets and roadmaps. It is imperative, during these annual discussions, that you talk about your platform’s health, direction, and upgrade strategy for the year, along with how it fits into the overall goals and KPIs of the business. During quarterly conversations, make sure the annual plan you created is still aligned with your current situation or pivot if not. The goal of this Upgrade Plan Checklist is to help you plan and schedule Adobe Commerce upgrades, to ensure a successful upgrade process during the year. This checklist is meant to be used by the following audiences for annual planning and quarterly review:
 
 * Director / Manager IT
 * eCommerce Manager
@@ -11,7 +11,7 @@ Use this checklist during your annual and quarterly conversations with your ecom
 
 >![info]
 >
->Note: For a detailed description of the technical steps to upgrade successfully refer to [Update and upgrade checklist](https://devdocs.magento.com/guides/v2.4/comp-mgr/prereq/prereq_compman-checklist.html) in our developer documentation.
+>Note: For a detailed description of the technical steps to upgrade successfully refer to [Complete upgrade prerequisites](https://devdocs.magento.com/guides/v2.4/comp-mgr/prereq/prereq_compman-checklist.html) in Adobe Experience League.
 
  **Goals**
 
@@ -29,7 +29,7 @@ Use this checklist during your annual and quarterly conversations with your ecom
 
  **Budget & Timing**
 
- **▢** Use the Adobe Commerce [release calendar](https://devdocs.magento.com/release/) to plan your next upgrade and prepare ahead of time.
+ **▢** Use the Adobe Commerce [release schedule](https://devdocs.magento.com/release/) to plan your next upgrade and prepare ahead of time.
 
  **▢** Discuss which version you think you’ll adopt (full or security-only) based on anticipated needs.
 
@@ -37,7 +37,7 @@ Use this checklist during your annual and quarterly conversations with your ecom
 
  **3rd Party Integrations**
 
- **▢** Review current Adobe Commerce 3rd party integrations you have and their maintenance windows for the year, you may want to align your upgrades together.
+ **▢** Review current Adobe Commerce third-party integrations and their maintenance windows for the year, and consider aligning upgrade work with your maintenance schedule.
 
  **Scope & Deployment Planning**
 
@@ -48,13 +48,13 @@ Use this checklist during your annual and quarterly conversations with your ecom
 
 ▢    Agree on budget, timeline, scope.
 
-▢    Run the [Upgrade Compatibility Tool](https://devdocs.magento.com/upgrade-compatibility-tool/introduction.html) to identify potential issues prior to upgrading.
+▢    Run the [Upgrade Compatibility Tool](https://experienceleague.adobe.com/docs/commerce-operations/upgrade-guide/prepare/prerequisites.html) to identify potential issues before upgrading.
 
 ▢    Consider using the upgrade to address issues identified by the [Site Wide Analysis Tool](https://docs.magento.com/user-guide/reports/site-wide-analysis-tool.html).
 
 ▢    Document dependencies and any technical stack changes required such as PHP or Elastic Search versions.
 
-▢    Gather project team w/ Adobe Commerce certifications.
+▢    Gather project team with Adobe Commerce certifications.
 
 ▢    Create stakeholder communication plan.
 
@@ -62,15 +62,15 @@ Use this checklist during your annual and quarterly conversations with your ecom
 
 ▢    Review and approve the testing strategy; consider using the Adobe Commerce [test framework](https://devdocs.magento.com/mftf/v2/docs/introduction.html) or a 3rd party automation suite.
 
-▢    Confirm all extensions / customizations are compatible.
+▢    Confirm that all extensions and customizations are compatible.
 
-▢    Review and update post launch playbook, to use if issues are discovered during or after upgrade.
+▢    Review and update the post launch playbook, to use if issues are discovered during or after upgrade.
 
  **Post Deployment**
 
 ▢    Monitor site for issues – performance, order processing, analytics, and others.
 
-▢    Perform Adobe Commerce [security scan](https://account.magento.com/scanner/dashboard/) or other 3rd party scan and review potential security vulnerabilities.
+▢    Perform an Adobe Commerce [security scan](https://account.magento.com/scanner/dashboard/) or other 3rd party scan and review potential security vulnerabilities.
 
 ▢    Perform a retrospective with all stakeholders and document what went well and what didn’t and how to improve.
 


### PR DESCRIPTION
## Purpose of this pull request
 
Upgrade documentation was refactored and moved from Adobe Commerce developer documentation to Experience League (ExL). This PR updates the link and reference to the technical details for upgrade preparation from magento.devdocs.com to ExL.
 
## Affected Support KB pages

https://support.magento.com/hc/en-us/articles/360057968951
